### PR TITLE
Pass configuration to OpenAPIParser

### DIFF
--- a/lib/apicraft/loader.rb
+++ b/lib/apicraft/loader.rb
@@ -35,16 +35,14 @@ module Apicraft
                  YAML.load_file(file)
                end
 
-      OpenAPIParser.parse(
-        parsed,
-        {
-          strict_reference_validation: config.strict_reference_validation,
-          expand_reference: true
-        }
-      )
-
       Openapi::Contract.create!(
-        OpenAPIParser.parse(parsed)
+        OpenAPIParser.parse(
+          parsed,
+          {
+            strict_reference_validation: config.strict_reference_validation,
+            expand_reference: true
+          }
+        )
       )
     end
   end


### PR DESCRIPTION
Resolves issue where deprecation notice for strict_reference_validation is raised incorrectly